### PR TITLE
Work around ld64 hardening trap in Lima build with lld

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -122,6 +122,13 @@
                         hash = "sha256-eyvz7XbZKUVQZdSVmDmYlHQSCKFE23OeIH4N4hNDg3M=";
                       };
                       vendorHash = "sha256-nwNDuE76fVncegDKI/Fztpc30NX8/shNbSfzkrwTPDk=";
+                      # Work around the ld64 libc++-hardening trap that crashes
+                      # the Objective-C stubs pass when linking (SIGTRAP in
+                      # ld::passes::objc). Link with LLVM lld instead, matching
+                      # the mitigation used across Nixpkgs; drop once this is
+                      # fixed upstream: https://github.com/NixOS/nixpkgs/issues/536365
+                      nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ final.llvmPackages.lld ];
+                      NIX_CFLAGS_LINK = "-fuse-ld=lld";
                     });
                 })
               ];

--- a/flake.nix
+++ b/flake.nix
@@ -122,12 +122,11 @@
                         hash = "sha256-eyvz7XbZKUVQZdSVmDmYlHQSCKFE23OeIH4N4hNDg3M=";
                       };
                       vendorHash = "sha256-nwNDuE76fVncegDKI/Fztpc30NX8/shNbSfzkrwTPDk=";
-                      # Work around the ld64 libc++-hardening trap that crashes
-                      # the Objective-C stubs pass when linking (SIGTRAP in
-                      # ld::passes::objc). Link with LLVM lld instead, matching
-                      # the mitigation used across Nixpkgs; drop once this is
-                      # fixed upstream: https://github.com/NixOS/nixpkgs/issues/536365
-                      nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ final.llvmPackages.lld ];
+
+                      # until https://github.com/NixOS/nixpkgs/issues/536365
+                      nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
+                        final.llvmPackages.lld
+                      ];
                       NIX_CFLAGS_LINK = "-fuse-ld=lld";
                     });
                 })


### PR DESCRIPTION
Workaround until NixOS/nixpkgs#536365 is merged.