### PR TITLE
Undo custom Lima lld override

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -122,12 +122,6 @@
                         hash = "sha256-eyvz7XbZKUVQZdSVmDmYlHQSCKFE23OeIH4N4hNDg3M=";
                       };
                       vendorHash = "sha256-nwNDuE76fVncegDKI/Fztpc30NX8/shNbSfzkrwTPDk=";
-
-                      # until https://github.com/NixOS/nixpkgs/issues/536365
-                      nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
-                        final.llvmPackages.lld
-                      ];
-                      NIX_CFLAGS_LINK = "-fuse-ld=lld";
                     });
                 })
               ];


### PR DESCRIPTION
This PR essentially reverts #182 since it started causing [the update workflow to fail](https://github.com/samestep/env/actions/runs/29322195669/job/87050060154) after NixOS/nixpkgs#541023 was merged.